### PR TITLE
New method to pad harder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/filecoin-project/go-state-types v0.0.0-20200903145444-247639ffa6ad
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi

--- a/go.sum
+++ b/go.sum
@@ -41,7 +41,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/padreader.go
+++ b/padreader.go
@@ -5,24 +5,27 @@ import (
 	"math/bits"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	"golang.org/x/xerrors"
 )
 
-// PaddedSize takes size to the next power of two and then returns the number of
-// not-bit-padded bytes that would fit into a sector of that size.
+// PaddedSize is an unfortunately-misnamed method: it returns the `unpadded`
+// (payload bearing) size of the smallest piece that could fit the provided
+// `size` payload.
 func PaddedSize(size uint64) abi.UnpaddedPieceSize {
 	if size <= 127 {
 		return abi.UnpaddedPieceSize(127)
 	}
 
-	logv := 64 - bits.LeadingZeros64(size)
+	// round to the nearest 127-divisible, find out fr32-padded size
+	paddedPieceSize := (size + 126) / 127 * 128
 
-	sectSize := uint64(1 << logv)
-	bound := abi.PaddedPieceSize(sectSize).Unpadded()
-	if size <= uint64(bound) {
-		return bound
+	// round up if not power of 2
+	if bits.OnesCount64(paddedPieceSize) != 1 {
+		paddedPieceSize = 1 << uint(64-bits.LeadingZeros64(paddedPieceSize))
 	}
 
-	return abi.PaddedPieceSize(1 << (logv + 1)).Unpadded() // nolint: typecheck
+	// get the unpadded size of the now-determind piece
+	return abi.PaddedPieceSize(paddedPieceSize).Unpadded()
 }
 
 type nullReader struct{}
@@ -37,12 +40,31 @@ func (nr nullReader) Read(b []byte) (int, error) {
 
 // New produces a reader that produces the provided reader's bytes with a suffix
 // of NUL bytes.
-func New(r io.Reader, size uint64) (io.Reader, abi.UnpaddedPieceSize) {
-	padSize := PaddedSize(size)
+func New(r io.Reader, readerTotalSize uint64) (io.Reader, abi.UnpaddedPieceSize) {
+	padSize := PaddedSize(readerTotalSize)
 	n := uint64(padSize)
+	return io.MultiReader(
+		io.LimitReader(r, int64(readerTotalSize)),
+		io.LimitReader(nullReader{}, int64(n-readerTotalSize)),
+	), padSize
+}
+
+// NewInflator wraps a reader so that it will return enough bytes to exactly
+// fill the given PieceSize
+func NewInflator(r io.Reader, readerTotalSize uint64, targetSize abi.UnpaddedPieceSize) (io.Reader, error) {
+	if bits.OnesCount64(uint64(targetSize.Padded())) != 1 {
+		return nil, xerrors.Errorf("supplied targetSize %d does not correspond to a power-of-2 piece", targetSize)
+	}
+	if targetSize < 127 {
+		targetSize = 127
+	}
+
+	if readerTotalSize > uint64(targetSize) {
+		return nil, xerrors.Errorf("supplied readerTotalSize %d is larger than the target PieceSize %d", readerTotalSize, targetSize)
+	}
 
 	return io.MultiReader(
-		io.LimitReader(r, int64(size)),
-		io.LimitReader(nullReader{}, int64(n-size)),
-	), padSize
+		io.LimitReader(r, int64(readerTotalSize)),
+		io.LimitReader(nullReader{}, int64(targetSize)-int64(readerTotalSize)),
+	), nil
 }


### PR DESCRIPTION
Because we use the `PadReader` directly during `AP` we **may** need a way to return a controlled amount of zeroes (alternative would be to keep precise track of sector offsets for each piece which is just too much work for a seldom used feature)

cc @whyrusleeping - this is needed to unblock a forgotten branch